### PR TITLE
Task/sapnamysore/tlt 2097/ui updates

### DIFF
--- a/canvas_course_admin_tools/templates/canvas_course_admin_tools/dashboard_course.html
+++ b/canvas_course_admin_tools/templates/canvas_course_admin_tools/dashboard_course.html
@@ -20,7 +20,7 @@
                 <h3>Manage Course</h3>
                 <div class="list-group">
                     <a href="{% if icm_active %}{% url 'isites_migration:index' %}{% else %}#{% endif %}" class="list-group-item {% if icm_active %}active{% else %}disabled{% endif %}">
-                        <h4 class="list-group-item-heading">iSites Content Migration</h4>
+                        <h4 class="list-group-item-heading">Import iSites Content</h4>
                         <p class="list-group-item-text">Migrate content from a previous term's Course iSite to this Canvas course</p>
                     </a>
                 </div>

--- a/canvas_course_admin_tools/views.py
+++ b/canvas_course_admin_tools/views.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 def tool_config(request):
     url = "%s://%s%s" % (request.scheme, request.get_host(),
                          reverse('lti_launch', exclude_resource_link_id=True))
-    title = 'Course Admin Tasks'
+    title = 'Import iSites Content'
     lti_tool_config = ToolConfig(
         title=title,
         launch_url=url,
@@ -48,7 +48,7 @@ def tool_config(request):
 @require_http_methods(['POST'])
 @csrf_exempt
 def lti_launch(request):
-    return redirect('dashboard_course')
+    return redirect('isites_migration:index')
 
 
 @login_required

--- a/isites_migration/templates/isites_migration/index.html
+++ b/isites_migration/templates/isites_migration/index.html
@@ -14,7 +14,7 @@
 {% block content %}
 <header>
     <div class="row lti-header">
-        <h1>iSites Content Migration</h1>
+        <h1>Import iSites Content</h1>
     </div>
 </header>
 
@@ -31,14 +31,22 @@
                     {% endfor %}
                 </select>
             </div>
-            <button id="begin-import" type="submit" class="btn btn-primary" disabled="disabled"><i class="fa fa-download"></i> Begin iSites Import</button>
+            <button id="begin-import" type="submit" class="btn btn-primary" disabled="disabled"><i class="fa fa-download"></i>Import</button>
         </form>
+        <p>
+            <div class="alert alert-info alert-dismissible" role="alert">
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
+                This migration will include files (e.g. pdfs, Word documents, etc.) and text box content (e.g. iSites text areas). It will not include web links, single images, students' submitted dropbox content, videos from the Video Publishing Tool, lecture videos, discussions, student-generated content (dropbox, video submissions, quizzes) and web links (including linked YouTube videos in Video Publishing Tool.)
+                <br />&nbsp;<br />
+                iSites listed here are those that you’ve been associated with in a teaching staff role. All the imported material can be found in the <a href="#" class="alert-link">Files</a> area of this Canvas course site. The folder named with the imported iSite’s keyword is set as unpublished, you will have to publish it manually by selecting the cloud icon. You can also add these files directly to your Canvas <a href="#" class="alert-link">Pages</a>, <a href="#" class="alert-link">Announcements</a>, etc… using the File Browser, shown in the right hand panel when you enter into edit mode in these tools.
+            </div>
+        </p>
         <table class="table table-striped">
             <thead>
                 <tr>
                     <th>Started At</th>
                     <th>iSites Keyword</th>
-                    <th>State</th>
+                    <th>Status</th>
                 </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
This PR contains some UI updates to the tool  and navigation changes as outlined in https://jira.huit.harvard.edu/browse/TLT-2097.

Regarding the navigation change, while this story was groomed, it was decided to directly link to the iSites migration links without restructuring the tool( so we can add more tools to course admin tools if needed  in the future as it was originally designed. Currently, iSites migration is the only tool).

Also note that the explanatory text blurb may change. Currently it is based on the wiki mockups.
