### PR TITLE
Task/eparker71/tlt 2098 display more info for isites content import

### DIFF
--- a/canvas_course_admin_tools/views.py
+++ b/canvas_course_admin_tools/views.py
@@ -11,7 +11,7 @@ from ims_lti_py.tool_config import ToolConfig
 
 from async.models import Process
 
-from isites_migration.utils import get_previous_isites_keywords
+from isites_migration.utils import get_previous_isites
 
 
 logger = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ def lti_launch(request):
 def dashboard_course(request):
     course_instance_id = request.LTI.get('lis_course_offering_sourcedid')
     # Check to see if we have any iSites that are available for migration to this Canvas course
-    icm_active = len(get_previous_isites_keywords(course_instance_id)) > 0
+    icm_active = len(get_previous_isites(course_instance_id)) > 0
     return render(request, 'canvas_course_admin_tools/dashboard_course.html', {
         'icm_active': icm_active
     })

--- a/isites_migration/templates/isites_migration/index.html
+++ b/isites_migration/templates/isites_migration/index.html
@@ -43,7 +43,7 @@
             <form class="form-inline" method="POST" action="{% url 'isites_migration:index' %}">
                 {% csrf_token %}
 
-                <table class="table table-striped">
+                <table id="select-site-table" class="table table-striped">
                     <thead>
                         <tr>
                             <th><i class="fa fa-download"></i></th>
@@ -110,6 +110,14 @@
 <script>
     $(document).ready(function(){
 
+        // only show the more button if there are more than 3 rows
+        var rowCount = $('#select-site-table tr').length;
+        if(rowCount <= 3) {
+            console.log('boo');
+            $('#show-more').addClass('hidden');
+        }
+
+        // control how the more and less button are displayed
         $('#show-more').click(function(){
             $(this).addClass('hidden');
             $('#show-less').removeClass('hidden');
@@ -142,6 +150,7 @@
             $('#hidden-term-id').val($(this).data("term"));
             $('#hidden-title-id').val($(this).data("title"));
 
+            // only enable the submit button if a radio option is checked
             if($('input[name="keyword"]:checked').size() > 0) {
                 $('#begin-import').prop('disabled', false);
             }

--- a/isites_migration/templates/isites_migration/index.html
+++ b/isites_migration/templates/isites_migration/index.html
@@ -55,7 +55,7 @@
                     <tbody>
                     {% for site in isites %}
                          <tr align="left" {% if forloop.counter > 3 %} class="collapsible" {% endif %}>
-                             <th scope="row"><input type="radio" name="keyword" value="site.keyword"></th>
+                             <th scope="row"><input type="radio" name="keyword" value="site.keyword" data-title="{{ site.title }}" data-term="{{ site.term }}"></th>
                              <td><a href="http://isites.harvard.edu/{{ site.keyword }}" target="_blank">{{ site.keyword }}</a></td>
                              <td>{{ site.title }}</td>
                              <td>{{ site.term }}</td>
@@ -63,10 +63,9 @@
                     {% endfor %}
                     </tbody>
                 </table>
-
+                <input id="hidden-title-id" type="hidden" name="title" value="None">
+                <input id="hidden-term-id" type="hidden" name="term" value="None">
                 <button id="begin-import" type="submit" class="btn btn-primary pull-left" title="Migrate files from selected iSites Course" disabled="disabled"><i class="fa fa-download"></i> Import</button>
-
-                <button id="cancel-import" type="submit" class="btn btn-default pull-left hidden" title="Migrate files from selected iSites Course"><i class="fa fa-times"></i> Cancel Content Import</button>
 
                 <a href="#" id="show-more" class="pull-right">More <i class="fa fa-arrow-down"></i></a>
                 <a href="#" id="show-less" class="pull-right hidden">Less <i class="fa fa-arrow-up"></i></a>
@@ -74,13 +73,16 @@
             </div>
         </div>
 
+        <h3 class="">Imported iSite(s)</h3>
 
         <table class="table table-striped">
             <thead>
                 <tr>
                     <th>Started At</th>
-                    <th>iSites Keyword</th>
-                    <th>Status</th>
+                    <th>iSite</th>
+                    <th>iSite Course Title</th>
+                    <th>iSite Course Term</th>
+                    <th>Status of Import</th>
                 </tr>
             </thead>
             <tbody>
@@ -88,6 +90,8 @@
                 <tr>
                     <td>{{ p.date_created|format_datetime }}</td>
                     <td>{{ p.details.keyword }}</td>
+                    <td>{{ p.details.title }}</td>
+                    <td>{{ p.details.term }}</td>
                     <td><span class="process-state label">{{ p.status_display }}</span></td>
                 </tr>
                 {% endfor %}
@@ -135,7 +139,15 @@
 
         // Activate import button when a keyword is selected
         $('input[name="keyword"]:radio').change(function(){
-            $('#begin-import').prop('disabled', false);
+            $('#hidden-term-id').val($(this).data("term"));
+            $('#hidden-title-id').val($(this).data("title"));
+
+            if($('input[name="keyword"]:checked').size() > 0) {
+                $('#begin-import').prop('disabled', false);
+            }
+            else {
+                $('#begin-import').prop('disabled', true);
+            }
         });
 
         {% if has_active_process %}

--- a/isites_migration/templates/isites_migration/index.html
+++ b/isites_migration/templates/isites_migration/index.html
@@ -8,6 +8,9 @@
     .content form {
         text-align: center;
     }
+    .collapsible {
+        display: none;
+    }
 </style>
 {% endblock stylesheets %}
 
@@ -20,27 +23,58 @@
 
 <main>
     <div class="content">
-        {% if keywords %}
-        <form class="form-inline" method="POST" action="{% url 'isites_migration:index' %}">
-            {% csrf_token %}
-            <div class="form-group">
-                <select id="keyword" name="keyword" class="form-control">
-                    <option value="">Select a Course iSite</option>
-                    {% for keyword in keywords %}
-                    <option value="{{ keyword }}">{{ keyword }}</option>
+
+        <div class="alert alert-warning" role="alert" hidden="">
+          This Canvas course is not associated with any Course iSites.
+        </div>
+
+        <div class="alert alert-info alert-dismissible" role="alert">
+          <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
+          This migration will include files (e.g. pdfs, Word documents, etc.) and text box content (e.g. iSites text areas). It will not include web links, single images, students' submitted dropbox content, videos from the Video Publishing Tool, lecture videos, discussions, student-generated content (dropbox, video submissions, quizzes) and web links (including linked YouTube videos in Video Publishing Tool.)
+          <br />&nbsp;<br />
+          iSites listed here are those that you’ve been associated with in a teaching staff role. All the imported material can be found in the <a href="#" class="alert-link">Files</a> area of this Canvas course site. The folder named with the imported iSite’s keyword is set as unpublished, you will have to publish it manually by selecting the cloud icon. You can also add these files directly to your Canvas <a href="#" class="alert-link">Pages</a>, <a href="#" class="alert-link">Announcements</a>, etc… using the File Browser, shown in the right hand panel when you enter into edit mode in these tools.
+        </div>
+
+
+        <div class="panel panel-default ">
+
+            <div class="panel-body"><h3>Choose an iSite to Import</h3>
+            {% if isites %}
+            <form class="form-inline" method="POST" action="{% url 'isites_migration:index' %}">
+                {% csrf_token %}
+
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th><i class="fa fa-download"></i></th>
+                            <th>iSites Keyword</th>
+                            <th>Course Title</th>
+                            <th>Term</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for site in isites %}
+                         <tr align="left" {% if forloop.counter > 3 %} class="collapsible" {% endif %}>
+                             <th scope="row"><input type="radio" name="keyword" value="site.keyword"></th>
+                             <td><a href="http://isites.harvard.edu/{{ site.keyword }}" target="_blank">{{ site.keyword }}</a></td>
+                             <td>{{ site.title }}</td>
+                             <td>{{ site.term }}</td>
+                        </tr>
                     {% endfor %}
-                </select>
+                    </tbody>
+                </table>
+
+                <button id="begin-import" type="submit" class="btn btn-primary pull-left" title="Migrate files from selected iSites Course" disabled="disabled"><i class="fa fa-download"></i> Import</button>
+
+                <button id="cancel-import" type="submit" class="btn btn-default pull-left hidden" title="Migrate files from selected iSites Course"><i class="fa fa-times"></i> Cancel Content Import</button>
+
+                <a href="#" id="show-more" class="pull-right">More <i class="fa fa-arrow-down"></i></a>
+                <a href="#" id="show-less" class="pull-right hidden">Less <i class="fa fa-arrow-up"></i></a>
+            </form>
             </div>
-            <button id="begin-import" type="submit" class="btn btn-primary" disabled="disabled"><i class="fa fa-download"></i>Import</button>
-        </form>
-        <p>
-            <div class="alert alert-info alert-dismissible" role="alert">
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
-                This migration will include files (e.g. pdfs, Word documents, etc.) and text box content (e.g. iSites text areas). It will not include web links, single images, students' submitted dropbox content, videos from the Video Publishing Tool, lecture videos, discussions, student-generated content (dropbox, video submissions, quizzes) and web links (including linked YouTube videos in Video Publishing Tool.)
-                <br />&nbsp;<br />
-                iSites listed here are those that you’ve been associated with in a teaching staff role. All the imported material can be found in the <a href="#" class="alert-link">Files</a> area of this Canvas course site. The folder named with the imported iSite’s keyword is set as unpublished, you will have to publish it manually by selecting the cloud icon. You can also add these files directly to your Canvas <a href="#" class="alert-link">Pages</a>, <a href="#" class="alert-link">Announcements</a>, etc… using the File Browser, shown in the right hand panel when you enter into edit mode in these tools.
-            </div>
-        </p>
+        </div>
+
+
         <table class="table table-striped">
             <thead>
                 <tr>
@@ -71,6 +105,19 @@
 {% block javascript %}
 <script>
     $(document).ready(function(){
+
+        $('#show-more').click(function(){
+            $(this).addClass('hidden');
+            $('#show-less').removeClass('hidden');
+            $('.collapsible').toggle();
+        });
+
+        $('#show-less').click(function(){
+            $(this).addClass('hidden');
+            $('#show-more').removeClass('hidden');
+            $('.collapsible').toggle();
+        });
+
         // Add appropriate label class to state column
         $('.process-state').each(function(){
             var $label = $(this);
@@ -85,11 +132,12 @@
             }
             $(this).addClass(stateClass);
         });
+
         // Activate import button when a keyword is selected
-        $('#keyword').on('change', function(){
-            var hasSelection = $(this).find('option:selected').val() != '';
-            $('#begin-import').prop('disabled', !hasSelection);
+        $('input[name="keyword"]:radio').change(function(){
+            $('#begin-import').prop('disabled', false);
         });
+
         {% if has_active_process %}
         // Refresh to update process states
         setTimeout(function(){

--- a/isites_migration/utils.py
+++ b/isites_migration/utils.py
@@ -165,7 +165,7 @@ def lock_canvas_folder(canvas_course_id, folder_name):
         raise
 
 
-def get_previous_isites_keywords(course_instance_id):
+def get_previous_isites(course_instance_id):
     """
     Given a course_instance_id, finds iSite keywords mapped to previous offerings of the course
 
@@ -177,6 +177,7 @@ def get_previous_isites_keywords(course_instance_id):
     :return: The set of iSite keywords
     """
     previous_keywords = set()
+    previous_sites = []
     try:
         course_instance = CourseInstance.objects.get(course_instance_id=course_instance_id)
     except CourseInstance.DoesNotExist:
@@ -209,17 +210,24 @@ def get_previous_isites_keywords(course_instance_id):
     # the course instance's list of enrollment viewer managers intersects
     # with the current course instance's list of enrollment viewer managers
     for previous_instance_id in previous_instance_ids:
-        keywords = {m.course_site.external_id for m in SiteMap.objects.filter(
+        sites = [{'keyword' : m.course_site.external_id,
+                  'title': m.course_instance.title,
+                  'term': m.course_instance.term.display_name,
+                  'calendar_year': m.course_instance.term.calendar_year } for m in SiteMap.objects.filter(
             course_instance_id=previous_instance_id,
             course_site__site_type_id='isite'
-        )}
-        if keywords:
+        )]
+        if sites:
             cursor.execute(evm_sql_query, [previous_instance_id])
             previous_evm_user_ids = {user_id for (ci_id, user_id) in cursor.fetchall()}
             if previous_evm_user_ids & evm_user_ids:
-                previous_keywords = previous_keywords | keywords
+                for site in sites:
+                    previous_sites.append(site)
 
-    return previous_keywords
+    # case insensitive sort the sections in alpha order
+    previous_sites = sorted(previous_sites, key=lambda x: x[u'calendar_year'], reverse=True)
+
+    return previous_sites
 
 
 def _export_file_repository(file_repository, keyword, topic_title):

--- a/isites_migration/utils.py
+++ b/isites_migration/utils.py
@@ -174,14 +174,13 @@ def get_previous_isites(course_instance_id):
     repname=Perl.CourseManager&path=%2Fbranches%2Fmod_perl2_2%2Flib%2FCourseTools%2FNewCourseSiteWizard.pm
 
     :param course_instance_id:
-    :return: The set of iSite keywords
+    :return: The list of dicts that contain the keyword, title, and term.
     """
-    previous_keywords = set()
     previous_sites = []
     try:
         course_instance = CourseInstance.objects.get(course_instance_id=course_instance_id)
     except CourseInstance.DoesNotExist:
-        return previous_keywords
+        return previous_sites
 
     # Collect the iSites keywords associated with previous offerings of the given course instance
     course = course_instance.course
@@ -224,8 +223,9 @@ def get_previous_isites(course_instance_id):
                 for site in sites:
                     previous_sites.append(site)
 
-    # case insensitive sort the sections in alpha order
-    previous_sites = sorted(previous_sites, key=lambda x: x[u'calendar_year'], reverse=True)
+    # sort the dicts by calendar_year in descending order
+    if previous_sites:
+        previous_sites = sorted(previous_sites, key=lambda x: x[u'calendar_year'], reverse=True)
 
     return previous_sites
 

--- a/isites_migration/views.py
+++ b/isites_migration/views.py
@@ -21,10 +21,14 @@ def index(request):
     canvas_course_id = request.LTI.get('custom_canvas_course_id')
     if request.method == 'POST':
         keyword = request.POST.get('keyword')
+        title = request.POST.get('title')
+        term = request.POST.get('term')
         Process.enqueue(
             migrate_files,
             'isites_file_migration',
             keyword=keyword,
+            title=title,
+            term=term,
             canvas_course_id=canvas_course_id
         )
         return redirect('isites_migration:index')

--- a/isites_migration/views.py
+++ b/isites_migration/views.py
@@ -7,7 +7,7 @@ from django.shortcuts import render, redirect
 from lti_permissions.decorators import lti_permission_required
 from async.models import Process
 
-from isites_migration.utils import get_previous_isites_keywords
+from isites_migration.utils import get_previous_isites
 from isites_migration.jobs import migrate_files
 
 
@@ -36,7 +36,7 @@ def index(request):
 
     has_active_process = len([p for p in processes if p.state != Process.COMPLETE]) > 0
     return render(request, 'isites_migration/index.html', {
-        'keywords': get_previous_isites_keywords(course_instance_id),
+        'isites': get_previous_isites(course_instance_id),
         'processes': processes,
         'has_active_process': has_active_process
     })


### PR DESCRIPTION
Jira ticket: https://jira.huit.harvard.edu/browse/TLT-2098

Places to look harder:
the method get_previous_isites on line 160 of utils.py
the form "form-inline" on line 43 of index.html

This PR contains updates to the isites_migration tool. There are some text and UI edits along with some logic changes. The main logic change can be found in the file utils file in the method get_previous_isites.
This method used to be called "get_previous_isites_keywords", I changed to get_previous_isites as the nature of the data returned changed. The method now builds a dict for each isite found that contains the following:

{
    "keyword" : "k12345",
    "title": "this is some course",
    "term": "Fall 2015",
    "calendar_year": 2005
}

The last column calendar year, is only there for sorting purposes. The rest of the data is now being displayed in the UI. 

Per the ticket, the drop down select input field has been replaced with a table that contains the info above. The form inputs are now radio buttons.

On first display, the table will only show 3 rows. If the table has more than 3 rows a "more" button will be displayed below the table. If the "more" button is clicked, a "less" button will be displayed. 

To pass the title and term values as hidden fields, I place the data on the radio button using the html data attribute. Then in javascript when a user clicks a radio button the hidden fields are updated with the correct values for the selected radio option. 
