### PR TITLE
Task/eparker71/tlt 2099 provide stats to ba's

### DIFF
--- a/canvas_course_admin_tools/requirements/base.txt
+++ b/canvas_course_admin_tools/requirements/base.txt
@@ -12,6 +12,6 @@ ndg-httpsclient==0.4.0
 boto==2.38.0
 kitchen==1.2.1
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.8.1#egg=canvas-python-sdk==0.8.1
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.7#egg=django-icommons-common==1.10.7
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.16#egg=django-icommons-common==1.10.16
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.4#egg=django-auth-lti==1.2.4

--- a/isites_migration/templates/isites_migration/index.html
+++ b/isites_migration/templates/isites_migration/index.html
@@ -24,90 +24,87 @@
 <main>
     <div class="content">
 
-        <div class="alert alert-warning" role="alert" hidden="">
-          This Canvas course is not associated with any Course iSites.
-        </div>
-
-        <div class="alert alert-info alert-dismissible" role="alert">
-          <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
-
-            The iSites listed here are previous offerings of this course that share at least one teaching staff member
-            with the current offering. Once the import is complete, visit the <a href="{{link_to_files_page}}" target="_blank" class="alert-link">Files</a> area in this Canvas
-            course site and look for the main archive folder named “unpublished_isites_archive_kxxxxxx.” This folder is
-            unpublished, and <b>therefore students cannot access the files.</b> To make files available to students, you must
-            first publish this main archive folder.
-            <br />&nbsp;<br />
-            Note: This content import will include files (e.g. pdfs, Word documents, etc.) and text box content
-            (e.g. iSites text areas), but will not include web links, videos, discussions, single images, and students'
-            dropbox submissions.
-        </div>
-
-
-        <div class="panel panel-default ">
-
-            <div class="panel-body"><h3>Choose an iSite to Import</h3>
-            {% if isites %}
-            <form class="form-inline" method="POST" action="{% url 'isites_migration:index' %}">
-                {% csrf_token %}
-
-                <table id="select-site-table" class="table table-striped">
-                    <thead>
-                        <tr>
-                            <th><i class="fa fa-download"></i></th>
-                            <th>iSites Keyword</th>
-                            <th>Course Title</th>
-                            <th>Term</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                    {% for site in isites %}
-                         <tr align="left" {% if forloop.counter > 3 %} class="collapsible" {% endif %}>
-                             <th scope="row"><input type="radio" name="keyword" value="site.keyword" data-title="{{ site.title }}" data-term="{{ site.term }}"></th>
-                             <td><a href="http://isites.harvard.edu/{{ site.keyword }}" target="_blank">{{ site.keyword }}</a></td>
-                             <td>{{ site.title }}</td>
-                             <td>{{ site.term }}</td>
-                        </tr>
-                    {% endfor %}
-                    </tbody>
-                </table>
-                <input id="hidden-title-id" type="hidden" name="title" value="None">
-                <input id="hidden-term-id" type="hidden" name="term" value="None">
-                <button id="begin-import" type="submit" class="btn btn-primary pull-left" title="Migrate files from selected iSites Course" disabled="disabled"><i class="fa fa-download"></i> Import</button>
-
-                <a href="#" id="show-more" class="pull-right hidden">More <i class="fa fa-arrow-down"></i></a>
-                <a href="#" id="show-less" class="pull-right hidden">Less <i class="fa fa-arrow-up"></i></a>
-            </form>
+        {% if not isites %}
+            <div class="alert alert-info" role="alert">
+              This Canvas course is not associated with any Course iSites.
             </div>
-        </div>
-
-        <h3 class="">Imported iSite(s)</h3>
-
-        <table class="table table-striped">
-            <thead>
-                <tr>
-                    <th>Started At</th>
-                    <th>iSite</th>
-                    <th>iSite Course Title</th>
-                    <th>iSite Course Term</th>
-                    <th>Status of Import</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for p in processes %}
-                <tr>
-                    <td>{{ p.date_created|format_datetime }}</td>
-                    <td>{{ p.details.keyword }}</td>
-                    <td>{{ p.details.title }}</td>
-                    <td>{{ p.details.term }}</td>
-                    <td><span class="process-state label">{{ p.status_display }}</span></td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
         {% else %}
-        <div class="alert alert-info" role="alert">
-            This Canvas course is not associated with any Course iSites.
-        </div>
+            <div class="alert alert-info alert-dismissible" role="alert">
+              <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">×</span></button>
+
+                The iSites listed here are previous offerings of this course that share at least one teaching staff member
+                with the current offering. Once the import is complete, visit the <a href="{{link_to_files_page}}" target="_blank" class="alert-link">Files</a> area in this Canvas
+                course site and look for the main archive folder named “unpublished_isites_archive_kxxxxxx.” This folder is
+                unpublished, and <b>therefore students cannot access the files.</b> To make files available to students, you must
+                first publish this main archive folder.
+                <br />&nbsp;<br />
+                Note: This content import will include files (e.g. pdfs, Word documents, etc.) and text box content
+                (e.g. iSites text areas), but will not include web links, videos, discussions, single images, and students'
+                dropbox submissions.
+            </div>
+
+
+            <div class="panel panel-default ">
+
+                <div class="panel-body"><h3>Choose an iSite to Import</h3>
+
+                <form class="form-inline" method="POST" action="{% url 'isites_migration:index' %}">
+                    {% csrf_token %}
+
+                    <table id="select-site-table" class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th><i class="fa fa-download"></i></th>
+                                <th>iSites Keyword</th>
+                                <th>Course Title</th>
+                                <th>Term</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        {% for site in isites %}
+                             <tr align="left" {% if forloop.counter > 3 %} class="collapsible" {% endif %}>
+                                 <th scope="row"><input type="radio" name="keyword" value="site.keyword" data-title="{{ site.title }}" data-term="{{ site.term }}"></th>
+                                 <td><a href="http://isites.harvard.edu/{{ site.keyword }}" target="_blank">{{ site.keyword }}</a></td>
+                                 <td>{{ site.title }}</td>
+                                 <td>{{ site.term }}</td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                    <input id="hidden-title-id" type="hidden" name="title" value="None">
+                    <input id="hidden-term-id" type="hidden" name="term" value="None">
+                    <button id="begin-import" type="submit" class="btn btn-primary pull-left" title="Migrate files from selected iSites Course" disabled="disabled"><i class="fa fa-download"></i> Import</button>
+
+                    <a href="#" id="show-more" class="pull-right hidden">More <i class="fa fa-arrow-down"></i></a>
+                    <a href="#" id="show-less" class="pull-right hidden">Less <i class="fa fa-arrow-up"></i></a>
+                </form>
+                </div>
+            </div>
+
+            <h3 class="">Imported iSite(s)</h3>
+
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>Started At</th>
+                        <th>iSite</th>
+                        <th>iSite Course Title</th>
+                        <th>iSite Course Term</th>
+                        <th>Status of Import</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for p in processes %}
+                    <tr>
+                        <td>{{ p.date_created|format_datetime }}</td>
+                        <td>{{ p.details.keyword }}</td>
+                        <td>{{ p.details.title }}</td>
+                        <td>{{ p.details.term }}</td>
+                        <td><span class="process-state label">{{ p.status_display }}</span></td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
         {% endif %}
     </div>
 </main>

--- a/isites_migration/utils.py
+++ b/isites_migration/utils.py
@@ -82,15 +82,16 @@ def export_files(keyword):
                 file_path = os.path.join(root, file)
                 z_file.write(file_path, file_path[zip_path_index:])
         z_file.close()
-        logger.info('Created zip file %s' % zip_filename)
+
+        logger.info('Creating zip file %s' % zip_filename)
         zf_info = zipfile.ZipFile(zip_filename)
         compressed_size = 0
         uncompressed_size = 0
         for z_info in zf_info.infolist():
             compressed_size += z_info.compress_size
             uncompressed_size += z_info.file_size
-
         z_file.close()
+
         logger.info('Compressed: %s bytes' % compressed_size)
         logger.info('Uncompressed: %s bytes' % uncompressed_size)
 
@@ -287,7 +288,7 @@ def _export_file_repository(file_repository, keyword, topic_title):
                             d_file.write(to_bytes(line, 'utf8'))
             except IOError:
                 logger.exception(
-                    "Failed to export file node %s from file repository % in keyword %s",
+                    u"Failed to export file node %d from file repository %d in keyword %s",
                     file_node.file_node_id,
                     file_repository.file_repository_id,
                     keyword

--- a/isites_migration/utils.py
+++ b/isites_migration/utils.py
@@ -35,7 +35,7 @@ if hasattr(ssl, '_create_unverified_context'):
     ssl._create_default_https_context = ssl._create_unverified_context
 
 
-def get_school(course_instance_id=None, canvas_course_id=None):
+def get_school(course_instance_id, canvas_course_id):
     """
      get the school_id for the course_instance_id or the canvas_course_id provided.
     :param course_instance_id:
@@ -44,22 +44,19 @@ def get_school(course_instance_id=None, canvas_course_id=None):
     """
     school = None
 
-    if course_instance_id:
-        try:
-            ci = CourseInstance.objects.get(course_instance_id=course_instance_id)
-            school = ci.course.school_id
-        except CourseInstance.DoesNotExist as e:
-            logger.exception(u'course_instance_id %s does not exist: %s' % course_instance_id, e)
-            return school
-
-    if canvas_course_id:
-        try:
-            ci = CourseInstance.objects.get(canvas_course_id=canvas_course_id)
-            school = ci.course.school_id
-        except CourseInstance.DoesNotExist as e:
-            logger.exception(u'canvas_course_id %s does not exist: %s' % canvas_course_id, e)
-            return school
-
+    try:
+        ci = CourseInstance.objects.get(course_instance_id=course_instance_id)
+        school = ci.course.school_id
+    except CourseInstance.DoesNotExist:
+        logger.exception(u'course_instance_id %s does not exist' % course_instance_id)
+        if canvas_course_id:
+            ci = CourseInstance.objects.get_primary_course_by_canvas_course_id(canvas_course_id)
+            if ci:
+                school = ci.course.school_id
+             else:
+                logger.warning(
+                    u'Could not determine the primary course instance for Canvas '
+                    u'course id %s', canvas_course_id)
     return school
 
 

--- a/isites_migration/utils.py
+++ b/isites_migration/utils.py
@@ -82,6 +82,18 @@ def export_files(keyword):
                 file_path = os.path.join(root, file)
                 z_file.write(file_path, file_path[zip_path_index:])
         z_file.close()
+        logger.info('Created zip file %s' % zip_filename)
+        zf_info = zipfile.ZipFile(zip_filename)
+        compressed_size = 0
+        uncompressed_size = 0
+        for z_info in zf_info.infolist():
+            compressed_size += z_info.compress_size
+            uncompressed_size += z_info.file_size
+
+        z_file.close()
+        logger.info('Compressed: %s bytes' % compressed_size)
+        logger.info('Uncompressed: %s bytes' % uncompressed_size)
+
         shutil.rmtree(keyword_export_path)
 
         export_key = Key(s3_bucket)

--- a/isites_migration/utils.py
+++ b/isites_migration/utils.py
@@ -92,8 +92,8 @@ def export_files(keyword):
             uncompressed_size += z_info.file_size
         z_file.close()
 
-        logger.info('Compressed: %s bytes' % compressed_size)
-        logger.info('Uncompressed: %s bytes' % uncompressed_size)
+        logger.info('Compressed: %d bytes' % compressed_size)
+        logger.info('Uncompressed: %d bytes' % uncompressed_size)
 
         shutil.rmtree(keyword_export_path)
 

--- a/isites_migration/utils.py
+++ b/isites_migration/utils.py
@@ -83,7 +83,7 @@ def export_files(keyword):
                 z_file.write(file_path, file_path[zip_path_index:])
         z_file.close()
 
-        # we want to log the size of the data we exporting pr TLT-2099
+        # we want to log the size of the data we exporting per TLT-2099
         logger.info('Creating zip file %s' % zip_filename)
         zf_info = zipfile.ZipFile(zip_filename)
         compressed_size = 0

--- a/isites_migration/utils.py
+++ b/isites_migration/utils.py
@@ -48,15 +48,19 @@ def get_school(course_instance_id, canvas_course_id):
         ci = CourseInstance.objects.get(course_instance_id=course_instance_id)
         school = ci.course.school_id
     except CourseInstance.DoesNotExist:
-        logger.exception(u'course_instance_id %s does not exist' % course_instance_id)
+        logger.exception(u'Could not determine the course instance for Canvas '
+                         u'course instance id %s' % course_instance_id)
         if canvas_course_id:
-            ci = CourseInstance.objects.get_primary_course_by_canvas_course_id(canvas_course_id)
-            if ci:
-                school = ci.course.school_id
-             else:
-                logger.warning(
-                    u'Could not determine the primary course instance for Canvas '
-                    u'course id %s', canvas_course_id)
+            try:
+                # get_primary_course_by_canvas_course_id could return None or throw
+                # a CourseInstance.DoesNotExist exception
+                ci = CourseInstance.objects.get_primary_course_by_canvas_course_id(canvas_course_id)
+                if ci:
+                    school = ci.course.school_id
+
+            except CourseInstance.DoesNotExist:
+                logger.exception(u'Could not determine the primary course instance for Canvas '
+                                 u'course id %s', canvas_course_id)
     return school
 
 

--- a/isites_migration/utils.py
+++ b/isites_migration/utils.py
@@ -83,6 +83,7 @@ def export_files(keyword):
                 z_file.write(file_path, file_path[zip_path_index:])
         z_file.close()
 
+        # we want to log the size of the data we exporting pr TLT-2099
         logger.info('Creating zip file %s' % zip_filename)
         zf_info = zipfile.ZipFile(zip_filename)
         compressed_size = 0

--- a/isites_migration/utils.py
+++ b/isites_migration/utils.py
@@ -35,6 +35,23 @@ if hasattr(ssl, '_create_unverified_context'):
     ssl._create_default_https_context = ssl._create_unverified_context
 
 
+def get_school(course_instance_id):
+    """
+    get the school_id for the course_instance_id provided.
+    :param course_instance_id:
+    :return school:
+    """
+    school = ''
+    try:
+        ci = CourseInstance.objects.get(course_instance_id=course_instance_id)
+        school = ci.course.school_id
+    except CourseInstance.DoesNotExist as e:
+        logger.exception(u'course instance id %s does not exist: %s' % course_instance_id, e)
+        return school
+
+    return school
+
+
 def export_files(keyword):
     try:
         s3_bucket = _get_s3_bucket(settings.AWS_EXPORT_BUCKET_ISITES_FILES)
@@ -73,28 +90,28 @@ def export_files(keyword):
 
             _export_topic_text(topic, keyword, topic_title)
 
+
+
         zip_path_index = len(settings.EXPORT_DIR) + 1
         keyword_export_path = os.path.join(settings.EXPORT_DIR, settings.CANVAS_IMPORT_FOLDER_PREFIX + keyword)
         zip_filename = os.path.join(settings.EXPORT_DIR, "%s%s.zip" % (settings.CANVAS_IMPORT_FOLDER_PREFIX, keyword))
+
+        # we want to log the size of the data we exporting per TLT-2099
+        logger.info('Creating zip file %s' % zip_filename)
         z_file = zipfile.ZipFile(zip_filename, 'w')
+        compressed_size = 0
+        uncompressed_size = 0
         for root, dirs, files in os.walk(keyword_export_path):
             for file in files:
                 file_path = os.path.join(root, file)
                 z_file.write(file_path, file_path[zip_path_index:])
+                z_info = z_file.getinfo(file_path[zip_path_index:])
+                compressed_size += z_info.compress_size
+                uncompressed_size += z_info.file_size
         z_file.close()
 
-        # we want to log the size of the data we exporting per TLT-2099
-        logger.info('Creating zip file %s' % zip_filename)
-        zf_info = zipfile.ZipFile(zip_filename)
-        compressed_size = 0
-        uncompressed_size = 0
-        for z_info in zf_info.infolist():
-            compressed_size += z_info.compress_size
-            uncompressed_size += z_info.file_size
-        z_file.close()
-
-        logger.info('Compressed: %d bytes' % compressed_size)
-        logger.info('Uncompressed: %d bytes' % uncompressed_size)
+        logger.info('Compressed: %s bytes' % compressed_size)
+        logger.info('Uncompressed: %s bytes' % uncompressed_size)
 
         shutil.rmtree(keyword_export_path)
 
@@ -289,7 +306,7 @@ def _export_file_repository(file_repository, keyword, topic_title):
                             d_file.write(to_bytes(line, 'utf8'))
             except IOError:
                 logger.exception(
-                    u"Failed to export file node %d from file repository %d in keyword %s",
+                    u"Failed to export file node %d from file repository %s in keyword %s",
                     file_node.file_node_id,
                     file_repository.file_repository_id,
                     keyword

--- a/isites_migration/utils.py
+++ b/isites_migration/utils.py
@@ -35,19 +35,30 @@ if hasattr(ssl, '_create_unverified_context'):
     ssl._create_default_https_context = ssl._create_unverified_context
 
 
-def get_school(course_instance_id):
+def get_school(course_instance_id=None, canvas_course_id=None):
     """
-    get the school_id for the course_instance_id provided.
+     get the school_id for the course_instance_id or the canvas_course_id provided.
     :param course_instance_id:
+    :param canvas_course_id:
     :return school:
     """
-    school = ''
-    try:
-        ci = CourseInstance.objects.get(course_instance_id=course_instance_id)
-        school = ci.course.school_id
-    except CourseInstance.DoesNotExist as e:
-        logger.exception(u'course instance id %s does not exist: %s' % course_instance_id, e)
-        return school
+    school = None
+
+    if course_instance_id:
+        try:
+            ci = CourseInstance.objects.get(course_instance_id=course_instance_id)
+            school = ci.course.school_id
+        except CourseInstance.DoesNotExist as e:
+            logger.exception(u'course_instance_id %s does not exist: %s' % course_instance_id, e)
+            return school
+
+    if canvas_course_id:
+        try:
+            ci = CourseInstance.objects.get(canvas_course_id=canvas_course_id)
+            school = ci.course.school_id
+        except CourseInstance.DoesNotExist as e:
+            logger.exception(u'canvas_course_id %s does not exist: %s' % canvas_course_id, e)
+            return school
 
     return school
 

--- a/isites_migration/views.py
+++ b/isites_migration/views.py
@@ -33,10 +33,12 @@ def index(request):
         )
         try:
             ci = CourseInstance.objects.get(course_instance_id=course_instance_id)
-            school = ci.term.school_id
-        except CourseInstance.DoesNotExist:
-            school = None
-        logger.info(u'migration started by user: %s, keyword:%s, title:%s, term:%s, canvas_course_id:%s,  school:%s' % (request.user.username, keyword, title, term, canvas_course_id, school))
+            school = ci.course.school_id
+        except CourseInstance.DoesNotExist as e:
+            school = ''
+            logger.exception(u'course instance id %s does not exist: %s' % course_instance_id, e)
+
+        logger.info(u'migration started by user: %s, keyword: %s, title: %s, term: %s, canvas_course_id: %s,  school: %s' % (request.user.username, keyword, title, term, canvas_course_id, school))
         return redirect('isites_migration:index')
 
     processes = Process.objects.filter(

--- a/isites_migration/views.py
+++ b/isites_migration/views.py
@@ -6,7 +6,7 @@ from django.shortcuts import render, redirect
 
 from lti_permissions.decorators import lti_permission_required
 from async.models import Process
-
+from icommons_common.models import CourseInstance
 from isites_migration.utils import get_previous_isites
 from isites_migration.jobs import migrate_files
 
@@ -31,6 +31,12 @@ def index(request):
             term=term,
             canvas_course_id=canvas_course_id
         )
+        try:
+            ci = CourseInstance.objects.get(course_instance_id=course_instance_id)
+            school = ci.term.school_id
+        except CourseInstance.DoesNotExist:
+            school = None
+        logger.info(u'migration started by user: %s, keyword:%s, title:%s, term:%s, canvas_course_id:%s,  school:%s' % (request.user.username, keyword, title, term, canvas_course_id, school))
         return redirect('isites_migration:index')
 
     processes = Process.objects.filter(

--- a/isites_migration/views.py
+++ b/isites_migration/views.py
@@ -39,7 +39,8 @@ def index(request):
         # if we have a course instance id, try that first.
         school = get_school(course_instance_id, canvas_course_id)
 
-        logger.info(u'migration started by user: %s, keyword: %s, title: %s, term: %s, canvas_course_id: %s,  school: %s' % (request.user.username, keyword, title, term, canvas_course_id, school))
+        logger.info(u'migration started %s %s %s %s %s %s %s' % (request.user.username, keyword, title, term,
+                                                                 course_instance_id, canvas_course_id, school))
         return redirect('isites_migration:index')
 
     processes = Process.objects.filter(

--- a/isites_migration/views.py
+++ b/isites_migration/views.py
@@ -7,7 +7,7 @@ from django.shortcuts import render, redirect
 from lti_permissions.decorators import lti_permission_required
 from async.models import Process
 from icommons_common.models import CourseInstance
-from isites_migration.utils import get_previous_isites
+from isites_migration.utils import get_previous_isites, get_school
 from isites_migration.jobs import migrate_files
 
 
@@ -31,12 +31,8 @@ def index(request):
             term=term,
             canvas_course_id=canvas_course_id
         )
-        try:
-            ci = CourseInstance.objects.get(course_instance_id=course_instance_id)
-            school = ci.course.school_id
-        except CourseInstance.DoesNotExist as e:
-            school = ''
-            logger.exception(u'course instance id %s does not exist: %s' % course_instance_id, e)
+
+        school = get_school(course_instance_id)
 
         logger.info(u'migration started by user: %s, keyword: %s, title: %s, term: %s, canvas_course_id: %s,  school: %s' % (request.user.username, keyword, title, term, canvas_course_id, school))
         return redirect('isites_migration:index')

--- a/isites_migration/views.py
+++ b/isites_migration/views.py
@@ -17,12 +17,15 @@ logger = logging.getLogger(__name__)
 @login_required
 @lti_permission_required(settings.PERMISSION_ISITES_MIGRATION_IMPORT_FILES)
 def index(request):
+
     course_instance_id = request.LTI.get('lis_course_offering_sourcedid')
     canvas_course_id = request.LTI.get('custom_canvas_course_id')
+
     if request.method == 'POST':
         keyword = request.POST.get('keyword')
         title = request.POST.get('title')
         term = request.POST.get('term')
+        school = None
         Process.enqueue(
             migrate_files,
             'isites_file_migration',
@@ -32,7 +35,12 @@ def index(request):
             canvas_course_id=canvas_course_id
         )
 
-        school = get_school(course_instance_id)
+        # try to get the school.
+        # if we have a course instance id, try that first.
+        if course_instance_id:
+            school = get_school(course_instance_id=course_instance_id)
+        elif canvas_course_id:
+            school = get_school(canvas_course_id=canvas_course_id)
 
         logger.info(u'migration started by user: %s, keyword: %s, title: %s, term: %s, canvas_course_id: %s,  school: %s' % (request.user.username, keyword, title, term, canvas_course_id, school))
         return redirect('isites_migration:index')

--- a/isites_migration/views.py
+++ b/isites_migration/views.py
@@ -37,10 +37,7 @@ def index(request):
 
         # try to get the school.
         # if we have a course instance id, try that first.
-        if course_instance_id:
-            school = get_school(course_instance_id=course_instance_id)
-        elif canvas_course_id:
-            school = get_school(canvas_course_id=canvas_course_id)
+        school = get_school(course_instance_id, canvas_course_id)
 
         logger.info(u'migration started by user: %s, keyword: %s, title: %s, term: %s, canvas_course_id: %s,  school: %s' % (request.user.username, keyword, title, term, canvas_course_id, school))
         return redirect('isites_migration:index')


### PR DESCRIPTION
Jira ticket: https://jira.huit.harvard.edu/browse/TLT-2099

This PR adds the following logging to the isites migration project:
1) number of sites that have been imported (the ability to calculate this happens in splunk)
2) from which schools/subaccounts
3) keyword/Canvas site ID for each import
4) size of each import
5) who ran each import
6) when each import was run
7) if the import was a success/failure

The main logging happens in the index view:

```
        logger.info(u'migration started by user: %s, keyword: %s, title: %s, term: %s, canvas_course_id: %s,  school: %s' % (request.user.username, keyword, title, term, canvas_course_id, school))

```

The other chunk of code to look at in in the util file in the export_files method. we need to calculate
the size of the data being exported. Using the same zip lib we use to create the file, we can calculate
the size of the data. 
line 86

```
        # we want to log the size of the data we exporting per TLT-2099
        logger.info('Creating zip file %s' % zip_filename)
        zf_info = zipfile.ZipFile(zip_filename)
        compressed_size = 0
        uncompressed_size = 0
        for z_info in zf_info.infolist():
            compressed_size += z_info.compress_size
            uncompressed_size += z_info.file_size
        z_file.close()

        logger.info('Compressed: %d bytes' % compressed_size)
        logger.info('Uncompressed: %d bytes' % uncompressed_size)

```
