### PR TITLE
removed term and title params from the enqueue call. the params were …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ secure*.py*
 !secure.py.example
 !secure.py.j2
 data/
+http_static/

--- a/isites_migration/views.py
+++ b/isites_migration/views.py
@@ -30,8 +30,6 @@ def index(request):
             migrate_files,
             'isites_file_migration',
             keyword=keyword,
-            title=title,
-            term=term,
             canvas_course_id=canvas_course_id
         )
 


### PR DESCRIPTION
…being passed on to the migrate files command which is the expected behavior but they are no longer needed and they were breaking the call.

also added http_static to .gitignore.
