### PR TITLE
Sprint 48: tlt-1870: dashboard - requirements fix

### DIFF
--- a/canvas_course_admin_tools/requirements/base.txt
+++ b/canvas_course_admin_tools/requirements/base.txt
@@ -1,4 +1,5 @@
-boto==2.38.0
+boto==2.40.0
+boto3==1.3.1
 Django==1.8.13
 django-redis-cache==1.6.5
 kitchen==1.2.1


### PR DESCRIPTION
fixes boto3 requirement removed in earlier cleanup commit, bumps boto requirement
