### PR TITLE
Sprint 48: TLT-1870 - dashboard permission messages

### DIFF
--- a/canvas_course_admin_tools/requirements/base.txt
+++ b/canvas_course_admin_tools/requirements/base.txt
@@ -7,4 +7,4 @@ redis==2.10.5
 psycopg2==2.6.1
 requests==2.9.1
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.8.4#egg=canvas-python-sdk==0.8.4
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.16#egg=django-icommons-common[async]==1.10.16
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.34#egg=django-icommons-common[async]==1.10.34

--- a/canvas_course_admin_tools/settings/base.py
+++ b/canvas_course_admin_tools/settings/base.py
@@ -271,7 +271,14 @@ ICOMMONS_COMMON = {
     },
 }
 
-PERMISSION_ISITES_MIGRATION_IMPORT_FILES = 'im_import_files'
+# lti_permissions.LtiPermission permission field for each app in the project
+# that uses it (this is used on the dashboard to determine which app links to
+# make available to the user
+CUSTOM_LTI_PERMISSIONS = {
+    'isites_migration': 'im_import_files',
+    'manage_course': 'manage_course',  # dashboard (canvas_course_admin_tools)
+    'manage_people': 'manage_people',
+}
 
 MANAGE_PEOPLE_MSGS = {
     'lti_request': 'There was a problem fulfilling your request. Please contact HUIT support.',

--- a/canvas_course_admin_tools/settings/base.py
+++ b/canvas_course_admin_tools/settings/base.py
@@ -276,7 +276,6 @@ ICOMMONS_COMMON = {
 # make available to the user
 CUSTOM_LTI_PERMISSIONS = {
     'isites_migration': 'im_import_files',
-    'manage_course': 'manage_course',  # dashboard (canvas_course_admin_tools)
     'manage_people': 'manage_people',
 }
 

--- a/canvas_course_admin_tools/templates/canvas_course_admin_tools/dashboard_course.html
+++ b/canvas_course_admin_tools/templates/canvas_course_admin_tools/dashboard_course.html
@@ -18,44 +18,55 @@
 <div class="row">
   <div class="col-md-6">
 
-      <div class="list-group">
-        {% if icm_active %}
-        <a href="{% url 'isites_migration:index' %}"
-           class="list-group-item active">
-          <h4 class="list-group-item-heading"> Import iSites Content </h4>
-          <p class="list-group-item-text">
-            Migrate content from a previous term's Course iSite to this
-            Canvas course (this text will change)
-          </p>
-        </a>
-        {% else %}
-        <div class="list-group-item active">
-          <h4 class="list-group-item-heading"> Import iSites Content </h4>
-          <p class="list-group-item-text">Course has no previous isites to import from
-          (this text will change)
-          </p>
-          </div>
-        {% endif %}
-      </div>
+  {% if no_tools_visible %}
+    You do not currently have access to any of the tools available in Manage Course. If you think you should have access, please use the ‘Help’ link in the bottom left corner of the screen to contact Canvas support from Harvard.
+  {% else %}
+      {% if isites_migration_visible %}
+        <div class="list-group">
+          {% if isites_migration_active %}
+          <a href="{% url 'isites_migration:index' %}"
+             class="list-group-item active">
+            <h4 class="list-group-item-heading"> Import iSites Content </h4>
+            <p class="list-group-item-text">
+              Migrate content from a previous term's Course iSite to this
+              Canvas course (this text will change)
+            </p>
+          </a>
+          {% else %}
+          <div class="list-group-item active">
+            <h4 class="list-group-item-heading"> Import iSites Content </h4>
+            <p class="list-group-item-text">Course has no previous isites to import from
+            (this text will change)
+            </p>
+            </div>
+          {% endif %}
+        </div>
+      {% endif %}
 
-    <div class="list-group">
-      <a href="{% url 'manage_people:user_form' %}"
-         class="list-group-item active">
-        <h4 class="list-group-item-heading"> Manage People </h4>
-        <p class="list-group-item-text">
-          Add or remove people from your course
-        </p>
-      </a>
-    </div>
-    <div class="list-group">
-      <a href="{% url 'manage_sections:create_section_form' %}"
-         class="list-group-item active">
-        <h4 class="list-group-item-heading"> Manage Sections </h4>
-        <p class="list-group-item-text">
-          Create, edit, and delete course sections
-        </p>
-      </a>
-    </div>
+      {% if manage_people_visible %}
+        <div class="list-group">
+          <a href="{% url 'manage_people:user_form' %}"
+             class="list-group-item active">
+            <h4 class="list-group-item-heading"> Manage People </h4>
+            <p class="list-group-item-text">
+              Add or remove people from your course
+            </p>
+          </a>
+        </div>
+      {% endif %}
+
+      {% if manage_sections_visible %}
+        <div class="list-group">
+          <a href="{% url 'manage_sections:create_section_form' %}"
+             class="list-group-item active">
+            <h4 class="list-group-item-heading"> Manage Sections </h4>
+            <p class="list-group-item-text">
+              Create, edit, and delete course sections
+            </p>
+          </a>
+        </div>
+      {% endif %}
+    {% endif %}
   </div>
 </div>
 </main>

--- a/canvas_course_admin_tools/views.py
+++ b/canvas_course_admin_tools/views.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
@@ -9,8 +10,13 @@ from django.views.decorators.http import require_http_methods
 
 from ims_lti_py.tool_config import ToolConfig
 
+from django_auth_lti.verification import is_allowed
 from isites_migration.utils import get_previous_isites
-
+from lti_permissions.decorators import (
+    lti_permission_required,
+    lti_permission_required_check,)
+from manage_sections.views import (
+    LTI_ROLES_PERMITTED as manage_sections_lti_roles_permitted,)
 
 logger = logging.getLogger(__name__)
 
@@ -45,16 +51,49 @@ def tool_config(request):
 @login_required
 @require_http_methods(['POST'])
 @csrf_exempt
+@lti_permission_required(settings.CUSTOM_LTI_PERMISSIONS['manage_course'])
 def lti_launch(request):
     return redirect('dashboard_course')
 
 
 @login_required
+@lti_permission_required(settings.CUSTOM_LTI_PERMISSIONS['manage_course'])
 def dashboard_course(request):
     course_instance_id = request.LTI.get('lis_course_offering_sourcedid')
+
+    # list of permissions to determine tool visibility
+    tools = {
+        'isites_migration': {
+            'visible': lti_permission_required_check(request, settings.CUSTOM_LTI_PERMISSIONS['isites_migration'])},
+        'manage_people': {
+            'visible': lti_permission_required_check(request, settings.CUSTOM_LTI_PERMISSIONS['manage_people'])},
+        'manage_sections': {
+            'visible': _lti_role_allowed(request, manage_sections_lti_roles_permitted)},
+    }
+
+    # django template tags can't do dict lookups, so create a *_visible context
+    # variable for each tool
+    tool_visibility = {
+        '{}_visible'.format(tool): tools[tool]['visible']
+        for tool in tools.keys()}
+
+    view_context = tool_visibility
+
+    # are all tools hidden?
+    no_tools_visible = len(filter(lambda x: x, tool_visibility.values())) == 0
+    view_context['no_tools_visible'] = no_tools_visible
+
     # Check to see if we have any iSites that are available for migration to
     # this Canvas course
     icm_active = len(get_previous_isites(course_instance_id)) > 0
-    return render(request, 'canvas_course_admin_tools/dashboard_course.html', {
-        'icm_active': icm_active
-    })
+    view_context['isites_migration_active'] = icm_active
+
+    return render(request, 'canvas_course_admin_tools/dashboard_course.html',
+                  view_context)
+
+
+def _lti_role_allowed(request, lti_roles_permitted, raise_exception=False):
+    """ utility method to convert is_allowed() to a boolean """
+    user_allowed_roles = is_allowed(request, lti_roles_permitted,
+                                    raise_exception)
+    return len(user_allowed_roles) > 0

--- a/canvas_course_admin_tools/views.py
+++ b/canvas_course_admin_tools/views.py
@@ -10,15 +10,22 @@ from django.views.decorators.http import require_http_methods
 
 from ims_lti_py.tool_config import ToolConfig
 
+from django_auth_lti import const
+from django_auth_lti.decorators import lti_role_required
 from django_auth_lti.verification import is_allowed
 from isites_migration.utils import get_previous_isites
-from lti_permissions.decorators import (
-    lti_permission_required,
-    lti_permission_required_check,)
+from lti_permissions.decorators import lti_permission_required_check
 from manage_sections.views import (
     LTI_ROLES_PERMITTED as manage_sections_lti_roles_permitted,)
 
 logger = logging.getLogger(__name__)
+
+LTI_ROLES_PERMITTED = [
+    const.ADMINISTRATOR,
+    const.CONTENT_DEVELOPER,
+    const.INSTRUCTOR,
+    const.TEACHING_ASSISTANT,
+]
 
 
 @require_http_methods(['GET'])
@@ -51,13 +58,13 @@ def tool_config(request):
 @login_required
 @require_http_methods(['POST'])
 @csrf_exempt
-@lti_permission_required(settings.CUSTOM_LTI_PERMISSIONS['manage_course'])
+@lti_role_required(LTI_ROLES_PERMITTED)
 def lti_launch(request):
     return redirect('dashboard_course')
 
 
 @login_required
-@lti_permission_required(settings.CUSTOM_LTI_PERMISSIONS['manage_course'])
+@lti_role_required(LTI_ROLES_PERMITTED)
 def dashboard_course(request):
     course_instance_id = request.LTI.get('lis_course_offering_sourcedid')
 

--- a/isites_migration/views.py
+++ b/isites_migration/views.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 @login_required
-@lti_permission_required(settings.PERMISSION_ISITES_MIGRATION_IMPORT_FILES)
+@lti_permission_required(settings.CUSTOM_LTI_PERMISSIONS['isites_migration'])
 def index(request):
 
     course_instance_id = request.LTI.get('lis_course_offering_sourcedid')

--- a/manage_people/views.py
+++ b/manage_people/views.py
@@ -49,6 +49,7 @@ from manage_people.models import ManagePeopleRole
 
 
 SDK_CONTEXT = SessionInactivityExpirationRC(**settings.CANVAS_SDK_SETTINGS)
+
 COURSE_MEMBER_CLASSES = (CourseEnrollee, CourseGuest, CourseStaff)
 
 logger = logging.getLogger(__name__)
@@ -63,9 +64,7 @@ def find_user(request):
 
 
 @login_required
-@lti_role_required([const.INSTRUCTOR, const.TEACHING_ASSISTANT,
-                    const.ADMINISTRATOR, const.CONTENT_DEVELOPER])
-@lti_permission_required('manage_people')
+@lti_permission_required(settings.CUSTOM_LTI_PERMISSIONS['manage_people'])
 @require_http_methods(['GET'])
 def user_form(request):
     # display the form to find a user
@@ -95,9 +94,7 @@ def user_form(request):
 
 
 @login_required
-@lti_role_required([const.INSTRUCTOR, const.TEACHING_ASSISTANT,
-                    const.ADMINISTRATOR, const.CONTENT_DEVELOPER])
-@lti_permission_required('manage_people')
+@lti_permission_required(settings.CUSTOM_LTI_PERMISSIONS['manage_people'])
 @require_http_methods(['GET'])
 def results_list(request):
     """ Display the list of matches; let the user select one or more """
@@ -255,9 +252,7 @@ def get_badge_info_for_users(user_id_list=None):
 
 
 @login_required
-@lti_role_required([const.INSTRUCTOR, const.TEACHING_ASSISTANT,
-                    const.ADMINISTRATOR, const.CONTENT_DEVELOPER])
-@lti_permission_required('manage_people')
+@lti_permission_required(settings.CUSTOM_LTI_PERMISSIONS['manage_people'])
 @require_http_methods(['POST'])
 def add_users(request):
     """
@@ -488,9 +483,7 @@ def get_enrollments_added_through_tool(sis_course_id):
 
 
 @login_required
-@lti_role_required([const.INSTRUCTOR, const.TEACHING_ASSISTANT,
-                    const.ADMINISTRATOR, const.CONTENT_DEVELOPER])
-@lti_permission_required('manage_people')
+@lti_permission_required(settings.CUSTOM_LTI_PERMISSIONS['manage_people'])
 @require_http_methods(['POST'])
 def remove_user(request):
     canvas_course_id = request.POST.get('canvas_course_id')

--- a/manage_sections/views.py
+++ b/manage_sections/views.py
@@ -39,6 +39,13 @@ ENROLLMENT_TYPES = [
     'StudentEnrollment', 'TeacherEnrollment', 'TaEnrollment', 'DesignerEnrollment', 'ObserverEnrollment'
 ]
 
+LTI_ROLES_PERMITTED = [
+    const.ADMINISTRATOR,
+    const.CONTENT_DEVELOPER,
+    const.INSTRUCTOR,
+    const.TEACHING_ASSISTANT,
+]
+
 
 class MonitorResponseView(BaseMonitorResponseView):
     def healthy(self):
@@ -118,7 +125,7 @@ def _add_badge_label_name_to_enrollments(enrollments):
 
 
 @login_required
-@lti_role_required([const.INSTRUCTOR, const.TEACHING_ASSISTANT, const.ADMINISTRATOR, const.CONTENT_DEVELOPER])
+@lti_role_required(LTI_ROLES_PERMITTED)
 @require_http_methods(['GET'])
 def create_section_form(request):
     try:
@@ -165,7 +172,7 @@ def create_section_form(request):
 
 
 @login_required
-@lti_role_required([const.INSTRUCTOR, const.TEACHING_ASSISTANT, const.ADMINISTRATOR, const.CONTENT_DEVELOPER])
+@lti_role_required(LTI_ROLES_PERMITTED)
 @require_http_methods(['POST'])
 def create_section(request):
     canvas_course_id = request.LTI['custom_canvas_course_id']
@@ -189,7 +196,7 @@ def create_section(request):
 
 
 @login_required
-@lti_role_required([const.INSTRUCTOR, const.TEACHING_ASSISTANT, const.ADMINISTRATOR, const.CONTENT_DEVELOPER])
+@lti_role_required(LTI_ROLES_PERMITTED)
 @require_http_methods(['POST'])
 def edit_section(request, section_id):
     canvas_course_id = request.LTI['custom_canvas_course_id']
@@ -248,7 +255,7 @@ def edit_section(request, section_id):
 
 
 @login_required
-@lti_role_required([const.INSTRUCTOR, const.TEACHING_ASSISTANT, const.ADMINISTRATOR, const.CONTENT_DEVELOPER])
+@lti_role_required(LTI_ROLES_PERMITTED)
 @require_http_methods(['GET'])
 def section_details(request, section_id):
     canvas_course_id = request.LTI['custom_canvas_course_id']
@@ -267,7 +274,7 @@ def section_details(request, section_id):
 
 
 @login_required
-@lti_role_required([const.INSTRUCTOR, const.TEACHING_ASSISTANT, const.ADMINISTRATOR, const.CONTENT_DEVELOPER])
+@lti_role_required(LTI_ROLES_PERMITTED)
 @require_http_methods(['GET'])
 def section_user_list(request, section_id):
     canvas_course_id = request.LTI['custom_canvas_course_id']
@@ -285,7 +292,7 @@ def section_user_list(request, section_id):
 
 
 @login_required
-@lti_role_required([const.INSTRUCTOR, const.TEACHING_ASSISTANT, const.ADMINISTRATOR, const.CONTENT_DEVELOPER])
+@lti_role_required(LTI_ROLES_PERMITTED)
 @require_http_methods(['POST'])
 def remove_section(request, section_id):
     canvas_course_id = request.LTI['custom_canvas_course_id']
@@ -312,7 +319,7 @@ def remove_section(request, section_id):
 
 
 @login_required
-@lti_role_required([const.INSTRUCTOR, const.TEACHING_ASSISTANT, const.ADMINISTRATOR, const.CONTENT_DEVELOPER])
+@lti_role_required(LTI_ROLES_PERMITTED)
 @require_safe
 def section_class_list(request, section_id):
     """
@@ -341,7 +348,7 @@ def section_class_list(request, section_id):
 
 
 @login_required
-@lti_role_required([const.INSTRUCTOR, const.TEACHING_ASSISTANT, const.ADMINISTRATOR, const.CONTENT_DEVELOPER])
+@lti_role_required(LTI_ROLES_PERMITTED)
 @require_http_methods(['POST'])
 def add_to_section(request):
     try:
@@ -379,7 +386,7 @@ def add_to_section(request):
 
 
 @login_required
-@lti_role_required([const.INSTRUCTOR, const.TEACHING_ASSISTANT, const.ADMINISTRATOR, const.CONTENT_DEVELOPER])
+@lti_role_required(LTI_ROLES_PERMITTED)
 @require_http_methods(['POST'])
 def remove_from_section(request):
     canvas_course_id = request.LTI['custom_canvas_course_id']


### PR DESCRIPTION
Dashboard now protected by custom lti permissions, and dashboard apps are visible based on their custom or traditional LTI permission configurations.
- no styling yet for 'no apps available message'
- note: removed the `lti_role_required()` in manage_people views as should be superseded by the more-configurable `lti_permission_required()`
