### PR TITLE
Sprint 48: TLT-2631 - lti resource link tests (TLT-1870)

### DIFF
--- a/canvas_course_admin_tools/settings/test.py
+++ b/canvas_course_admin_tools/settings/test.py
@@ -1,11 +1,14 @@
 from .local import *
 
 DATABASE_APPS_MAPPING = {
+    'auth': 'default',
+    'contenttypes': 'default',
     'icommons_common': 'default',
     'isites_migration': 'default',
     'lti_permissions': 'default',
     'manage_people': 'default',
     'manage_sections': 'default',
+    'sessions': 'default',
 }
 
 DATABASE_MIGRATION_WHITELIST = ['default']
@@ -37,3 +40,16 @@ MIDDLEWARE_CLASSES[MIDDLEWARE_CLASSES.index('cached_auth.Middleware')] = \
     'django.contrib.auth.middleware.AuthenticationMiddleware'
 MIDDLEWARE_CLASSES = tuple(MIDDLEWARE_CLASSES)
 SESSION_ENGINE = 'django.contrib.sessions.backends.db'
+
+"""
+Don't assume we'll have oauth credentials set for us in secure.py, set
+them up here instead.
+"""
+SECURE_SETTINGS.setdefault('lti_oauth_credentials', {}).update({'foo': 'bar'})
+if not LTI_OAUTH_CREDENTIALS:
+    LTI_OAUTH_CREDENTIALS = {}
+LTI_OAUTH_CREDENTIALS.update({'foo': 'bar'})
+SECURE_SETTINGS.setdefault('canvas_token', 'foo')
+if not CANVAS_SDK_SETTINGS:
+    CANVAS_SDK_SETTINGS = {}
+CANVAS_SDK_SETTINGS.update({'auth_token': 'foo'})

--- a/canvas_course_admin_tools/tests/test_lti_launch.py
+++ b/canvas_course_admin_tools/tests/test_lti_launch.py
@@ -1,0 +1,101 @@
+import copy
+import uuid
+
+import oauthlib
+
+import requests
+from django.test import LiveServerTestCase
+from mock import MagicMock, patch
+from requests_oauthlib import OAuth1Session
+
+from django_auth_lti import const
+
+
+@patch.multiple('lti_permissions.decorators', is_allowed=MagicMock(return_value=True))
+class LTIResourceLinkTests(LiveServerTestCase):
+    '''
+    Runs against a live server instance so we can use requests to test how
+    the server behaves when interacting with multiple tabs in the same session.
+
+    NOTE: The 'session.auth = None' lines are used to prevent the Oauth1Session
+    objects from continuing to sign further requests.  LTI only calls for the
+    launch to be signed.
+
+    NOTE: The foo/bar oauth credentials are added in unit_test settings.
+    '''
+    longMessage = True
+
+    def setUp(self):
+        self.resource_link_id = uuid.uuid4().hex
+        self.test_user = uuid.uuid4().hex
+        self.params = {
+            'custom_canvas_api_domain': 'canvas.harvard.edu',
+            'custom_canvas_course_id': '5',
+            'lis_course_offering_sourcedid': '5',
+            'lti_message_type': 'basic-lti-launch-request',
+            'lti_version': 'LTI-1p0',
+            'resource_link_id': self.resource_link_id,
+            'roles': ','.join([const.INSTRUCTOR, const.TEACHING_ASSISTANT,
+                               const.ADMINISTRATOR, const.CONTENT_DEVELOPER]),
+            'user_id': self.test_user,
+        }
+
+
+    @patch('canvas_course_admin_tools.views.get_previous_isites')
+    def test_lti_launch(self, mock_get_previous_isites):
+        mock_get_previous_isites.returns = []
+
+        # run the launch, verify we get redirected to a url ending in our
+        # resource_link_id
+        session = OAuth1Session(client_key='foo', client_secret='bar',
+                                signature_type=oauthlib.oauth1.SIGNATURE_TYPE_BODY)
+        url = self.live_server_url + '/lti_launch'
+        response = session.post(url, data=self.params, allow_redirects=False)
+        self.assertEqual(response.status_code, requests.codes.found)
+        self.assertIn('sessionid', response.cookies)
+        self.assertTrue(
+            response.headers['location'].endswith(self.resource_link_id))
+
+        # try following the redirect, we should get a 200
+        session.auth = None
+        response2 = session.get(response.headers['location'])
+        mock_get_previous_isites.assert_called_with(
+            self.params['lis_course_offering_sourcedid'])
+        self.assertEqual(response2.status_code, requests.codes.ok)
+
+    @patch('canvas_course_admin_tools.views.get_previous_isites')
+    def test_multiple_lti_launch(self, mock_get_previous_isites):
+        mock_get_previous_isites.returns = []
+
+        # run the launch, verify we get redirected to a url ending in our
+        # resource_link_id
+        session = OAuth1Session(client_key='foo', client_secret='bar',
+                                signature_type=oauthlib.oauth1.SIGNATURE_TYPE_BODY)
+        url = self.live_server_url + '/lti_launch'
+
+        # launch "tab 1" and verify success
+        response1 = session.post(url, data=self.params, allow_redirects=False)
+        self.assertEqual(response1.status_code, requests.codes.found)
+        self.assertIn('sessionid', response1.cookies)
+        self.assertTrue(
+            response1.headers['location'].endswith(self.resource_link_id))
+
+        # launch "tab 2" and verify success
+        params2 = copy.deepcopy(self.params)
+        params2['resource_link_id'] = uuid.uuid4().hex
+        response2 = session.post(url, data=params2, allow_redirects=False)
+        self.assertEqual(response2.status_code, requests.codes.found)
+        self.assertIn('sessionid', response2.cookies)
+        self.assertTrue(
+            response2.headers['location'].endswith(params2['resource_link_id']))
+
+        # follow the "tab 2" redirect and verify 200
+        session.auth = None
+        response3 = session.get(response2.headers['location'])
+        mock_get_previous_isites.assert_called_with(
+            self.params['lis_course_offering_sourcedid'])
+        self.assertEqual(response3.status_code, requests.codes.ok)
+
+        # follow the "tab 1" redirect and verify 200
+        response4 = session.get(response1.headers['location'])
+        self.assertEqual(response3.status_code, requests.codes.ok)

--- a/manage_people/tests/test_views.py
+++ b/manage_people/tests/test_views.py
@@ -1,17 +1,10 @@
-import copy
 import random
 import uuid
 
-import oauthlib
-from unittest import skip
-
-import requests
-from django.test import LiveServerTestCase, RequestFactory, TestCase
-from mock import patch, DEFAULT, Mock, MagicMock, ANY, call
-from requests_oauthlib import OAuth1Session
+from django.test import RequestFactory, TestCase
+from mock import patch, Mock, ANY, call
 
 from canvas_sdk.methods import enrollments
-from django_auth_lti import const
 from icommons_common.models import (
     CourseEnrollee,
     CourseGuest,
@@ -404,97 +397,3 @@ class GetBadgeInfoForUsersTests(TestCase):
         mock_person.return_value.values_list.side_effect = Exception
         with self.assertRaises(Exception):
             result = get_badge_info_for_users(self.user_id_input_list)
-
-
-@skip('oauth-related tests failing after porting app to new project')
-@patch.multiple('lti_permissions.decorators', is_allowed=MagicMock(return_value=True))
-class LTIResourceLinkTests(LiveServerTestCase):
-    '''
-    Runs against a live server instance so we can use requests to test how
-    the server behaves when interacting with multiple tabs in the same session.
-
-    For now, we're patching coursemanager objects because sqlite doesn't like
-    schema-scoped tables.
-
-    NOTE: The 'session.auth = None' lines are used to prevent the Oauth1Session
-    objects from continuing to sign further requests.  LTI only calls for the
-    launch to be signed.
-
-    NOTE: The foo/bar oauth credentials are added in unit_test settings.
-    '''
-    longMessage = True
-
-    def setUp(self):
-        self.resource_link_id = uuid.uuid4().hex
-        self.test_user = uuid.uuid4().hex
-        self.params = {
-            'custom_canvas_api_domain': 'canvas.harvard.edu',
-            'custom_canvas_course_id': '5',
-            'lis_course_offering_sourcedid': '5',
-            'lti_message_type': 'basic-lti-launch-request',
-            'lti_version': 'LTI-1p0',
-            'resource_link_id': self.resource_link_id,
-            'roles': ','.join([const.INSTRUCTOR, const.TEACHING_ASSISTANT,
-                               const.ADMINISTRATOR, const.CONTENT_DEVELOPER]),
-            'user_id': self.test_user,
-        }
-
-
-    @patch('manage_people.views.CourseInstance.objects.filter')
-    def test_lti_launch(self, mock_CourseInstance_filter):
-        mock_CourseInstance_filter.returns = []
-
-        # run the launch, verify we get redirected to a url ending in our
-        # resource_link_id
-        session = OAuth1Session(client_key='foo', client_secret='bar',
-                                signature_type=oauthlib.oauth1.SIGNATURE_TYPE_BODY)
-        url = self.live_server_url + '/lti_tools/manage_people/lti_launch'
-        response = session.post(url, data=self.params, allow_redirects=False)
-        self.assertEqual(response.status_code, requests.codes.found)
-        self.assertIn('sessionid', response.cookies)
-        self.assertTrue(
-            response.headers['location'].endswith(self.resource_link_id))
-
-        # try following the redirect, we should get a 200
-        session.auth = None
-        response2 = session.get(response.headers['location'])
-        mock_CourseInstance_filter.assert_called_with(
-            pk=self.params['lis_course_offering_sourcedid'])
-        self.assertEqual(response2.status_code, requests.codes.ok)
-
-    @patch('manage_people.views.CourseInstance.objects.filter')
-    def test_multiple_lti_launch(self, mock_CourseInstance_filter):
-        mock_CourseInstance_filter.returns = []
-
-        # run the launch, verify we get redirected to a url ending in our
-        # resource_link_id
-        session = OAuth1Session(client_key='foo', client_secret='bar',
-                                signature_type=oauthlib.oauth1.SIGNATURE_TYPE_BODY)
-        url = self.live_server_url + '/lti_tools/manage_people/lti_launch'
-
-        # launch "tab 1" and verify success
-        response1 = session.post(url, data=self.params, allow_redirects=False)
-        self.assertEqual(response1.status_code, requests.codes.found)
-        self.assertIn('sessionid', response1.cookies)
-        self.assertTrue(
-            response1.headers['location'].endswith(self.resource_link_id))
-
-        # launch "tab 2" and verify success
-        params2 = copy.deepcopy(self.params)
-        params2['resource_link_id'] = uuid.uuid4().hex
-        response2 = session.post(url, data=params2, allow_redirects=False)
-        self.assertEqual(response2.status_code, requests.codes.found)
-        self.assertIn('sessionid', response2.cookies)
-        self.assertTrue(
-            response2.headers['location'].endswith(params2['resource_link_id']))
-
-        # follow the "tab 2" redirect and verify 200
-        session.auth = None
-        response3 = session.get(response2.headers['location'])
-        mock_CourseInstance_filter.assert_called_with(
-            pk=self.params['lis_course_offering_sourcedid'])
-        self.assertEqual(response3.status_code, requests.codes.ok)
-
-        # follow the "tab 1" redirect and verify 200
-        response4 = session.get(response1.headers['location'])
-        self.assertEqual(response3.status_code, requests.codes.ok)


### PR DESCRIPTION
Enables and moves lti launch tests into dashboard app
