### PR TITLE
Raise system_exit error if regression_suite for selenium tests fails 

### DIFF
--- a/selenium_tests/regression_suite.py
+++ b/selenium_tests/regression_suite.py
@@ -48,4 +48,6 @@ suite = unittest.defaultTestLoader.discover(
 )
 
 # run the suite
-runner.run(suite)
+result = runner.run(suite)
+if not result.wasSuccessful():
+    raise SystemExit(1)


### PR DESCRIPTION
If regression_suite runs and any of the selenium tests fail, we need to raise an system exit.  
This way, Jenkins would display it as a failed job.

This change is now also consistent with other projects.
